### PR TITLE
Enable package to execute in Node.js projects (SSR environments)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easing-animation-frames",
-  "version": "0.0.8",
+  "version": "0.0.7",
   "description": "Lightweight library for creating animation",
   "module": "./src/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@prinzdezibel/easing-animation-frames",
-  "version": "0.0.9",
+  "name": "easing-animation-frames",
+  "version": "0.0.8",
   "description": "Lightweight library for creating animation",
   "module": "./src/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "easing-animation-frames",
-  "version": "0.0.7",
+  "name": "@prinzdezibel/easing-animation-frames",
+  "version": "0.0.9",
   "description": "Lightweight library for creating animation",
-  "main": "./src/index.js",
+  "module": "./src/index.js",
   "directories": {
     "example": "example"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import * as eases from 'eases-jsnext';
 
 // Polyfills
-const raf = typeof window !== 'undefined' && window.requestAnimationFrame || (callback => setTimeout(callback, 1000 / 60));
-const caf = typeof window !== 'undefined' && window.cancelAnimationFrame || (id => clearTimeout(id));
+const raf = typeof window !== 'undefined' ? window.requestAnimationFrame : (callback => setTimeout(callback, 1000 / 60));
+const caf = typeof window !== 'undefined' ? window.cancelAnimationFrame : (id => clearTimeout(id));
 
 /**
  * EASING ANIMATION FRAMES

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import * as eases from 'eases-jsnext';
 
 // Polyfills
-const raf = typeof window !== 'undefined' ? window.requestAnimationFrame : (callback => setTimeout(callback, 1000 / 60));
-const caf = typeof window !== 'undefined' ? window.cancelAnimationFrame : (id => clearTimeout(id));
+const raf = (typeof window !== 'undefined' && window.requestAnimationFrame) ? window.requestAnimationFrame : (callback => setTimeout(callback, 1000 / 60));
+const caf = (typeof window !== 'undefined' && window.cancelAnimationFrame) ? window.cancelAnimationFrame : (id => clearTimeout(id));
 
 /**
  * EASING ANIMATION FRAMES

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import * as eases from 'eases-jsnext';
 
 // Polyfills
-const raf = window.requestAnimationFrame || (callback => setTimeout(callback, 1000 / 60));
-const caf = window.cancelAnimationFrame || (id => clearTimeout(id));
+const raf = typeof window !== 'undefined' && window.requestAnimationFrame || (callback => setTimeout(callback, 1000 / 60));
+const caf = typeof window !== 'undefined' && window.cancelAnimationFrame || (id => clearTimeout(id));
 
 /**
  * EASING ANIMATION FRAMES


### PR DESCRIPTION
   Changes:

    - Explicitely state that the file is a esm module. Otherwise the node.js
    import mechanism expects a file in CommonJS format and loading of module
    will fail.

    - Guard window object in a SSR environment to prevent error 'window is
    not defined'